### PR TITLE
Fix #7

### DIFF
--- a/isolating_controller/isolation/isolators/memory.py
+++ b/isolating_controller/isolation/isolators/memory.py
@@ -1,6 +1,7 @@
 # coding: UTF-8
 
 import logging
+from itertools import chain
 
 from .base_isolator import Isolator
 from .. import NextStep
@@ -21,8 +22,7 @@ class MemoryIsolator(Isolator):
         self._cur_step = DVFS.MAX
 
     def __del__(self) -> None:
-        DVFS.set_freq(DVFS.MAX, self._fg_affinity)
-        DVFS.set_freq(DVFS.MAX, self._bg_affinity)
+        DVFS.set_freq(DVFS.MAX, chain(self._fg_affinity, self._bg_affinity))
 
     def strengthen(self) -> 'MemoryIsolator':
         self._cur_step -= DVFS.STEP

--- a/isolating_controller/isolation/isolators/schedule.py
+++ b/isolating_controller/isolation/isolators/schedule.py
@@ -15,8 +15,7 @@ class SchedIsolator(Isolator):
     def __init__(self, foreground_wl: Workload, background_wl: Workload) -> None:
         super().__init__(foreground_wl, background_wl)
 
-        self._fg_pid = foreground_wl.pid
-        self._bg_pid = background_wl.pid
+        self._prev_bg_affinity = background_wl.cpuset
         # FIXME: hard coded
         self._cur_step = 24
 
@@ -26,23 +25,8 @@ class SchedIsolator(Isolator):
         CgroupCpuset.assign(str(background_wl.pid), set(range(self._cur_step, 32)))
 
     def __del__(self) -> None:
-        if self._foreground_wl.is_running:
-            ended = self._fg_pid
-            running = self._bg_pid
-        else:
-            ended = self._bg_pid
-            running = self._fg_pid
-
-        CgroupCpuset.remove_group(str(ended))
-
-        with open(f'/sys/fs/cgroup/cpuset/{running}/tasks') as fp:
-            tasks = map(int, fp.readlines())
-
-        for tid in tasks:
-            subprocess.run(args=('sudo', 'tee', '-a', f'{CgroupCpuset.MOUNT_POINT}/tasks'),
-                           input=f'{tid}\n', check=True, encoding='ASCII', stdout=subprocess.DEVNULL)
-
-        CgroupCpuset.remove_group(str(running))
+        if self._background_wl.is_running:
+            CgroupCpuset.assign(str(self._background_wl.pid), set(self._prev_bg_affinity))
 
     def strengthen(self) -> 'SchedIsolator':
         self._cur_step += 1


### PR DESCRIPTION
Fix #7 

- isolation 종료 후 background의 cgroup을 삭제
- isolation 종료 후 foreground의 cgroup은 삭제하지 않도록 수정
  - foreground는 cgroup을 통해 cpuset을 제한하지 않으므로 필요없는 코드