### PR TITLE
Make logging more granular

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -222,14 +222,6 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    controller = MainController(args.buf_size)
-    controller.run()
-
-
-if __name__ == '__main__':
-    if sys.version_info < MIN_PYTHON:
-        sys.exit('Python {}.{} or later is required.\n'.format(*MIN_PYTHON))
-
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s]: %(message)s'))
 
@@ -244,5 +236,13 @@ if __name__ == '__main__':
     monitoring_logger = logging.getLogger('monitoring')
     monitoring_logger.setLevel(logging.INFO)
     module_logger.addHandler(stream_handler)
+
+    controller = MainController(args.buf_size)
+    controller.run()
+
+
+if __name__ == '__main__':
+    if sys.version_info < MIN_PYTHON:
+        sys.exit('Python {}.{} or later is required.\n'.format(*MIN_PYTHON))
 
     main()

--- a/isolating_controller/isolation/isolators/base_isolator.py
+++ b/isolating_controller/isolation/isolators/base_isolator.py
@@ -1,5 +1,6 @@
 # coding: UTF-8
 
+import logging
 from abc import ABCMeta, abstractmethod
 
 from .. import NextStep
@@ -53,9 +54,13 @@ class Isolator(metaclass=ABCMeta):
     def monitoring_result(self) -> NextStep:
         if self._force_strengthen:
             self._force_strengthen = False
+            logger = logging.getLogger(__name__)
+
             if self.is_max_level:
+                logger.debug('Not yet enforced, but there\'s no more configuration to search')
                 return NextStep.STOP
             else:
+                logger.debug('Not yet enforced, force strengthen isolation')
                 return NextStep.STRENGTHEN
 
         else:

--- a/isolating_controller/isolation/isolators/cache.py
+++ b/isolating_controller/isolation/isolators/cache.py
@@ -29,11 +29,15 @@ class CacheIsolator(Isolator):
             CAT.add_task(self._bg_grp_name, tid)
 
     def __del__(self) -> None:
+        logger = logging.getLogger(__name__)
+
         if self._foreground_wl.is_running:
+            logger.debug(f'reset resctrl configuration of {self._foreground_wl}')
             # FIXME: hard coded
             CAT.assign(self._fg_grp_name, '1', CAT.gen_mask(0, CAT.MAX))
 
         if self._background_wl.is_running:
+            logger.debug(f'reset resctrl configuration of {self._background_wl}')
             # FIXME: hard coded
             CAT.assign(self._bg_grp_name, '1', CAT.gen_mask(0, CAT.MAX))
 
@@ -96,10 +100,9 @@ class CacheIsolator(Isolator):
         prev_diff = self._prev_metric_diff.l3_hit_ratio
         diff_of_diff = curr_diff - prev_diff
 
-        # TODO: remove
         logger = logging.getLogger(__name__)
-        logger.info(f'diff of diff is {diff_of_diff}')
-        logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
+        logger.debug(f'diff of diff is {diff_of_diff:>7.4f}')
+        logger.debug(f'current diff: {curr_diff:>7.4f}, previous diff: {prev_diff:>7.4f}')
 
         self._prev_metric_diff = metric_diff
 

--- a/isolating_controller/isolation/isolators/cache.py
+++ b/isolating_controller/isolation/isolators/cache.py
@@ -67,7 +67,7 @@ class CacheIsolator(Isolator):
         return self._cur_step == CAT.MAX
 
     def _enforce(self) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
 
         if self._cur_step is None:
             logger.info(f'turn off CAT')
@@ -97,7 +97,7 @@ class CacheIsolator(Isolator):
         diff_of_diff = curr_diff - prev_diff
 
         # TODO: remove
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'diff of diff is {diff_of_diff}')
         logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
 

--- a/isolating_controller/isolation/isolators/memory.py
+++ b/isolating_controller/isolation/isolators/memory.py
@@ -41,7 +41,7 @@ class MemoryIsolator(Isolator):
         return self._cur_step == DVFS.MAX
 
     def _enforce(self) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'frequency of cpuset {self._background_wl.cpuset} is {self._cur_step / 1_000_000}GHz')
 
         DVFS.set_freq(self._cur_step, self._background_wl.cpuset)
@@ -54,7 +54,7 @@ class MemoryIsolator(Isolator):
         diff_of_diff = curr_diff - prev_diff
 
         # TODO: remove
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'diff of diff is {diff_of_diff}')
         logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
 

--- a/isolating_controller/isolation/isolators/memory.py
+++ b/isolating_controller/isolation/isolators/memory.py
@@ -53,10 +53,9 @@ class MemoryIsolator(Isolator):
         prev_diff = self._prev_metric_diff.local_mem_util
         diff_of_diff = curr_diff - prev_diff
 
-        # TODO: remove
         logger = logging.getLogger(__name__)
-        logger.info(f'diff of diff is {diff_of_diff}')
-        logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
+        logger.debug(f'diff of diff is {diff_of_diff:>7.4f}')
+        logger.debug(f'current diff: {curr_diff:>7.4f}, previous diff: {prev_diff:>7.4f}')
 
         self._prev_metric_diff = metric_diff
 

--- a/isolating_controller/isolation/isolators/schedule.py
+++ b/isolating_controller/isolation/isolators/schedule.py
@@ -50,7 +50,7 @@ class SchedIsolator(Isolator):
         return self._cur_step == 24
 
     def _enforce(self) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         # FIXME: hard coded
         logger.info(f'affinity of background is {self._cur_step}-31')
 
@@ -65,7 +65,7 @@ class SchedIsolator(Isolator):
         diff_of_diff = curr_diff - prev_diff
 
         # TODO: remove
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'diff of diff is {diff_of_diff}')
         logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
 

--- a/isolating_controller/isolation/isolators/schedule.py
+++ b/isolating_controller/isolation/isolators/schedule.py
@@ -64,10 +64,9 @@ class SchedIsolator(Isolator):
         prev_diff = self._prev_metric_diff.local_mem_util
         diff_of_diff = curr_diff - prev_diff
 
-        # TODO: remove
         logger = logging.getLogger(__name__)
-        logger.info(f'diff of diff is {diff_of_diff}')
-        logger.info(f'current diff: {curr_diff}, previous diff: {prev_diff}')
+        logger.debug(f'diff of diff is {diff_of_diff:>7.4f}')
+        logger.debug(f'current diff: {curr_diff:>7.4f}, previous diff: {prev_diff:>7.4f}')
 
         self._prev_metric_diff = metric_diff
 

--- a/isolating_controller/isolation/policies/base_policy.py
+++ b/isolating_controller/isolation/policies/base_policy.py
@@ -20,6 +20,9 @@ class IsolationPolicy(metaclass=ABCMeta):
     def __hash__(self) -> int:
         return self._fg_wl.pid
 
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__} <fg: {self._fg_wl}, bg: {self._bg_wl}>'
+
     def init_isolators(self) -> None:
         self._isolator_map = dict((
             (CacheIsolator, CacheIsolator(self._fg_wl, self._bg_wl)),

--- a/isolating_controller/isolation/policies/diff_policy.py
+++ b/isolating_controller/isolation/policies/diff_policy.py
@@ -25,7 +25,7 @@ class DiffPolicy(IsolationPolicy):
         self._is_sched_isolated = False
 
     def choose_next_isolator(self) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
 
         metric_diff = self._fg_wl.calc_metric_diff()
         # TODO: change level to debug

--- a/isolating_controller/isolation/policies/diff_policy.py
+++ b/isolating_controller/isolation/policies/diff_policy.py
@@ -4,6 +4,7 @@ import logging
 
 from .base_policy import IsolationPolicy
 from ..isolators import CacheIsolator, IdleIsolator, MemoryIsolator, SchedIsolator
+from ...metric_container.basic_metric import MetricDiff
 from ...workload import Workload
 
 
@@ -26,33 +27,35 @@ class DiffPolicy(IsolationPolicy):
 
     def choose_next_isolator(self) -> None:
         logger = logging.getLogger(__name__)
+        logger.debug('looking for new isolation...')
 
-        metric_diff = self._fg_wl.calc_metric_diff()
-        # TODO: change level to debug
-        logger.info(f'diff is {metric_diff}')
+        metric_diff: MetricDiff = self._fg_wl.calc_metric_diff()
+        logger.info(repr(metric_diff))
 
         l3_hit_ratio = abs(metric_diff.l3_hit_ratio)
         local_mem_util = abs(metric_diff.local_mem_util)
-        fg_name = self._fg_wl.name
-        fg_pid = self._fg_wl.pid
 
         if self._is_sched_isolated and self._is_mem_isolated and self._is_llc_isolated:
             self._clear_flags()
+            logger.debug('****All isolators are applicable for now!****')
 
         if not self._is_llc_isolated and l3_hit_ratio > local_mem_util:
             self._cur_isolator.yield_isolation()
             self._cur_isolator = self._isolator_map[CacheIsolator]
             self._is_llc_isolated = True
-            logger.info(f'Cache Isolation for workload {fg_name} (pid: {fg_pid}) is started')
+            logger.info(f'Cache Isolation for {self._fg_wl} is started')
 
         elif not self._is_mem_isolated and l3_hit_ratio < local_mem_util:
             self._cur_isolator.yield_isolation()
             self._cur_isolator = self._isolator_map[MemoryIsolator]
             self._is_mem_isolated = True
-            logger.info(f'Memory Bandwidth Isolation for workload {fg_name} (pid: {fg_pid}) is started')
+            logger.info(f'Memory Bandwidth Isolation for {self._fg_wl} is started')
 
         elif not self._is_sched_isolated and l3_hit_ratio < local_mem_util:
             self._cur_isolator.yield_isolation()
             self._cur_isolator = self._isolator_map[SchedIsolator]
             self._is_sched_isolated = True
-            logger.info(f'Cpuset Isolation for workload {fg_name} (pid: {fg_pid}) is started')
+            logger.info(f'Cpuset Isolation for {self._fg_wl} is started')
+
+        else:
+            logger.debug('A new Isolator has not been selected.')

--- a/isolating_controller/isolation/policies/diff_with_violation_policy.py
+++ b/isolating_controller/isolation/policies/diff_with_violation_policy.py
@@ -35,7 +35,7 @@ class DiffWViolationPolicy(DiffPolicy):
         if isinstance(self._cur_isolator, IdleIsolator):
             return True
 
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
 
         if self._check_violation():
             logger.info(f'violation is occurred. current isolator type : {self._cur_isolator.__class__.__name__}')
@@ -55,7 +55,7 @@ class DiffWViolationPolicy(DiffPolicy):
         return False
 
     def choose_next_isolator(self) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
 
         metric_diff = self._fg_wl.calc_metric_diff()
         # TODO: change level to debug

--- a/isolating_controller/metric_container/basic_metric.py
+++ b/isolating_controller/metric_container/basic_metric.py
@@ -124,4 +124,4 @@ class MetricDiff:
         return self._remote_mem
 
     def __repr__(self) -> str:
-        return f'L3 hit ratio: {self._l3_hit_ratio}, Local Memory access: {self._local_mem}'
+        return f'L3 hit ratio diff: {self._l3_hit_ratio:>6.03f}, Local Memory access diff: {self._local_mem:>6.03f}'

--- a/isolating_controller/workload.py
+++ b/isolating_controller/workload.py
@@ -29,7 +29,7 @@ class Workload:
         self._proc_info = psutil.Process(pid)
 
     def __repr__(self) -> str:
-        return 'Workload (pid: {}, perf_pid: {})'.format(self._pid, self._perf_pid)
+        return f'{self._name} (pid: {self._pid})'
 
     @property
     def name(self) -> str:

--- a/pending_queue.py
+++ b/pending_queue.py
@@ -22,7 +22,7 @@ class PendingQueue(Sized):
 
     def add_bg(self, workload: Workload) -> None:
         logger = logging.getLogger(__name__)
-        logger.info(f'{workload.name} (pid: {workload.pid}) is ready for active as Background')
+        logger.info(f'{workload} is ready for active as Background')
 
         # FIXME: hard coded
         other_cpuset = tuple(map(lambda x: x - 8, workload.cpuset))
@@ -37,7 +37,7 @@ class PendingQueue(Sized):
 
     def add_fg(self, workload: Workload) -> None:
         logger = logging.getLogger(__name__)
-        logger.info(f'{workload.name} (pid: {workload.pid}) is ready for active as Foreground')
+        logger.info(f'{workload} is ready for active as Foreground')
 
         # FIXME: hard coded
         other_cpuset = tuple(map(lambda x: x + 8, workload.cpuset))

--- a/pending_queue.py
+++ b/pending_queue.py
@@ -21,7 +21,7 @@ class PendingQueue(Sized):
                        self._pending_list)))
 
     def add_bg(self, workload: Workload) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'{workload.name} (pid: {workload.pid}) is ready for active as Background')
 
         # FIXME: hard coded
@@ -36,7 +36,7 @@ class PendingQueue(Sized):
             self._bg_q[workload.cpuset] = workload
 
     def add_fg(self, workload: Workload) -> None:
-        logger = logging.getLogger(self.__class__.__name__)
+        logger = logging.getLogger(__name__)
         logger.info(f'{workload.name} (pid: {workload.pid}) is ready for active as Foreground')
 
         # FIXME: hard coded


### PR DESCRIPTION
- Python의 `logger`를 목적에 따라 계층구조로 나눔
  1. 컨트롤러
    - `__main__`을 부모로하는 계층
    - `controller.py`내부에 쓰이는 `logger`
  2. 라이브러리
    - `isolating_controller`을 부모로하는 계층
    - `isolating_controller`모듈 내부에서 쓰이는 `logger`
  3. 모니터
    - `monitor`를 부모로하는 계층
    - RabbitMQ를 읽는 것과 관련된 `logger`

- `controller.py#main()`내부에서 각 계층의 레벨을 결정 가능