### PR TITLE
Fixes #6

### DIFF
--- a/isolating_controller/isolation/isolators/memory.py
+++ b/isolating_controller/isolation/isolators/memory.py
@@ -61,6 +61,7 @@ class MemoryIsolator(Isolator):
         self._prev_metric_diff = metric_diff
 
         if not (DVFS.MIN < self._cur_step < DVFS.MAX) \
+                or abs(diff_of_diff) <= MemoryIsolator._THRESHOLD \
                 or abs(curr_diff) <= MemoryIsolator._THRESHOLD:
             return NextStep.STOP
 

--- a/isolating_controller/isolation/isolators/schedule.py
+++ b/isolating_controller/isolation/isolators/schedule.py
@@ -86,6 +86,7 @@ class SchedIsolator(Isolator):
 
         # FIXME: hard coded
         if not (24 < self._cur_step < 31) \
+                or abs(diff_of_diff) <= SchedIsolator._THRESHOLD \
                 or abs(curr_diff) <= SchedIsolator._THRESHOLD:
             return NextStep.STOP
 


### PR DESCRIPTION
Fixes #6 

1. `mem_bw_util`의 계산식 #6 처럼 수정
2. (1)으로 인해 `diff_of_diff`를 `THRESHOLD`값으로 종료조건에 추가할 수 있었음